### PR TITLE
Add setup and backup scripts for Premiere Pro projects with READMEs

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="corretto-1.8" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/premiere-pro-scripts.iml" filepath="$PROJECT_DIR$/.idea/premiere-pro-scripts.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/premiere-pro-scripts.iml
+++ b/.idea/premiere-pro-scripts.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
-# premiere-pro-scripts
-This repo contains all the premiere pro scripts I use in my daily life
+# Premiere Pro Scripts
+
+This repository contains a collection of scripts designed to automate and enhance workflows related to Adobe Premiere Pro projects. These scripts aim to streamline operations such as backups and project setup, making it easier and more efficient to manage video editing tasks.
+
+## Repository Structure
+
+The repository is organized into subdirectories, each housing scripts related to specific functionalities:
+
+- **premiere-pro-backup**: Scripts for backing up Premiere Pro projects.
+- **premiere-pro-create**: Scripts for setting up new Premiere Pro projects.
+
+### Scripts
+
+#### 1. Premiere Pro Backup
+Located in the `premiere-pro-backup` directory, `premiere_pro_backup.sh` automates the process of backing up Premiere Pro project files to designated storage locations.
+
+#### 2. Premiere Pro Create
+Found in the `premiere-pro-create` directory, `premiere_pro_create.sh` facilitates the creation of new project structures, ensuring that all new projects adhere to a standardized format.
+
+## Getting Started
+
+To get started with these scripts:
+
+1. **Clone the Repository:**
+   ```bash
+   git clone https://github.com/yourusername/premiere-pro-scripts.git
+   cd premiere-pro-scripts
+

--- a/premiere-pro-backup/README.md
+++ b/premiere-pro-backup/README.md
@@ -1,0 +1,58 @@
+
+# Premiere Pro Project Backup Script
+
+## Overview
+
+This Bash script automates the process of backing up Adobe Premiere Pro project folders. It locates original project folders based on a given project number, checks for existing backups, and if not found, prompts for the backup location. The script ensures that the backup folder structure matches the original and handles file transfers to designated subdirectories.
+
+## Requirements
+
+- Bash shell (typically available on macOS and Linux)
+- Accessible storage volumes at specific paths (can be adjusted in the script):
+    - Original projects: `/Volumes/1TBSSD/# Projects/# YouTube Originals`
+    - Backup location: `/Volumes/2TBHDD/# Projects/# YouTube Backups [HDD]`
+
+## Usage
+
+To use this script, follow these steps:
+
+1. **Ensure Execution Permissions:**
+   Ensure the script is executable. If not, run the following command in your terminal:
+   ```bash
+   chmod +x backup_project.sh
+   ```
+
+2. **Run the Script:**
+   Execute the script by navigating to its directory and running:
+   ```bash
+   ./backup_project.sh
+   ```
+
+3. **Provide Input When Prompted:**
+   - **Project Number**: Input the project number as labeled in your project directory (e.g., `#069`).
+
+### Example of Running the Script:
+```bash
+./backup_project.sh
+Enter the project number (e.g., #069): #081
+Original project folder not found.
+Please enter the exact path of the copied project folder: /path/to/copied/folder
+Backup process completed successfully for project: Your_Project_Name
+```
+
+## Features
+
+- **Search and Validate**: Locates original and backup project folders based on user input.
+- **Dynamic Backup Handling**: Prompts for backup location if the backup is not initially found.
+- **Structured Backup Creation**: Ensures that the backup structure mirrors the original project folder, including subdirectories for project files, thumbnails, and exports.
+- **File Management**: Handles the movement and copying of files to maintain organization and integrity of the backup.
+
+## Important Notes
+
+- The script relies on specific naming conventions and directory structures. Ensure that your directories are structured as expected by the script or modify the script to suit your environment.
+- The script uses `sudo` for certain operations, which may require administrative privileges.
+
+## License
+
+This project is open-sourced under the MIT License. See the LICENSE file for more details.
+

--- a/premiere-pro-backup/premiere_pro_backup.sh
+++ b/premiere-pro-backup/premiere_pro_backup.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# Prompt the user for the project number
+read -p "Enter the project number (e.g., #069): " project_number
+
+# Define the source and destination paths
+backup_base="/Volumes/2TBHDD/# Projects/# YouTube Backups [HDD]"
+originals_base="/Volumes/1TBSSD/# Projects/# YouTube Originals"
+
+# Find the original project folder by the project number
+original_project_folder=$(find "${originals_base}" -type d -name "${project_number}*" | head -n 1)
+if [[ -z "$original_project_folder" ]]; then
+    echo "Original project folder not found."
+    exit 1
+fi
+
+# Extract the full name of the project folder
+project_folder_name=$(basename "$original_project_folder")
+
+# Find the copied project folder
+copied_folder=$(find "${backup_base}" -type d -name "Copied_${project_number}_*" | head -n 1)
+if [[ -z "$copied_folder" ]]; then
+    echo "Copied project folder not found."
+    read -p "Please enter the exact path of the copied project folder: " copied_folder
+    if [[ ! -d "$copied_folder" ]]; then
+        echo "No valid directory provided. Exiting."
+        exit 1
+    fi
+fi
+
+# Rename the copied project folder to match the original project folder name
+new_copied_folder="${backup_base}/${project_folder_name}"
+sudo mv "$copied_folder" "$new_copied_folder"
+copied_folder="$new_copied_folder"
+
+# Create necessary directories in the new copied folder
+sudo mkdir -p "${copied_folder}/01 Project Files"
+sudo mkdir -p "${copied_folder}/02 Thumbnail"
+sudo mkdir -p "${copied_folder}/03 Export"
+
+# Move all files to '01 Project Files', but keep the .prproj file outside
+find "${copied_folder}" -maxdepth 1 -type f ! -name '*.prproj' -exec sudo mv {} "${copied_folder}/01 Project Files" \;
+
+# Copy thumbnail files
+sudo cp -r "${original_project_folder}/09 Thumbnail/." "${copied_folder}/02 Thumbnail/"
+
+# Try to find the 4k export file in possible directories
+export_dirs=("10 Export" "Exports" "Export")
+for dir in "${export_dirs[@]}"; do
+    export_file=$(find "${original_project_folder}/${dir}" -type f -name 'Final_4k_SD*' | head -n 1)
+    if [[ -f "$export_file" ]]; then
+        sudo cp "$export_file" "${copied_folder}/03 Export/"
+        echo "Export file copied successfully."
+        break
+    fi
+done
+
+if [[ ! -f "$export_file" ]]; then
+    echo "Export file not found in expected directories."
+fi
+
+echo "Backup process completed successfully for project: $project_folder_name."

--- a/premiere-pro-create/README.md
+++ b/premiere-pro-create/README.md
@@ -1,0 +1,63 @@
+
+
+
+# Premiere Pro Project Setup Script
+
+## Overview
+
+This Bash script simplifies the creation of new Adobe Premiere Pro projects by automatically copying a predefined project template into a new project directory, which is named based on user input. Additionally, the script allows for selective inclusion of specific footage directories, catering to the unique needs of each project.
+
+## Requirements
+
+- Bash shell (typically available on macOS and Linux)
+- The project template should be located at: `/Volumes/1TBSSD/# Projects/# YouTube Originals/#999 Template`
+- The storage volume `/Volumes/1TBSSD` must be accessible and writable.
+
+## Usage
+
+To use this script, follow these steps:
+
+1. **Ensure Execution Permissions:**
+   Ensure the script is executable. If not, run the following command in your terminal:
+   ```bash
+   chmod +x create_project.sh
+   ```
+
+2. **Run the Script:**
+   Execute the script by navigating to its directory and running:
+   ```bash
+   ./create_project.sh
+   ```
+
+3. **Provide Input When Prompted:**
+   - **Project Code**: Input a numerical code for your project (e.g., `083`).
+   - **Project Title**: Input a descriptive title for your project (e.g., `How to Edit`).
+   - **Footage Directories**: Respond to prompts to include or exclude specific footage types (A7III, Screen, iPad, iPhone, GoPro).
+
+### Example of Running the Script:
+```bash
+./create_project.sh
+Enter the project code (e.g., 083): 083
+Enter the project title (e.g., How to Edit): How to Edit
+Include Footage from A7III? (y/n): y
+Include Screen Footage? (y/n): n
+Include iPad Footage? (y/n): y
+Include iPhone Footage? (y/n): n
+Include GoPro Footage? (y/n): y
+Project directory created successfully.
+```
+
+## Features
+
+- **Automated Directory Creation**: Sets up a new project directory with a structure based on a master template.
+- **Selective Footage Inclusion**: Users can choose which specific types of footage directories to include in the new project, ensuring flexibility.
+- **Consistency and Efficiency**: Utilizes a template for consistent project setups and increases efficiency in project creation.
+
+## Important Notes
+
+- Ensure that the paths and directory names used in the script match those on your system.
+- The script assumes a specific directory structure and naming convention; modifications might be necessary if your environment differs.
+
+## License
+
+This project is open-sourced under the MIT License. See the LICENSE file for more details.

--- a/premiere-pro-create/premiere_pro_create.sh
+++ b/premiere-pro-create/premiere_pro_create.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Set the template directory
+template_dir="/Volumes/1TBSSD/# Projects/# YouTube Originals/#999 Template"
+
+# Ask for user input
+read -p "Enter the project code (e.g., 083): " project_code
+read -p "Enter the project title (e.g., How to Edit): " project_title
+
+# Set the new project directory path
+new_project_dir="/Volumes/1TBSSD/# Projects/# YouTube Originals/#${project_code} ${project_title}"
+
+# Copy the template directory to a new location with the new project name
+cp -r "$template_dir" "$new_project_dir"
+
+# Rename the Master project file
+mv "${new_project_dir}/01 Project Files/Master.prproj" "${new_project_dir}/01 Project Files/#${project_code} Master.prproj"
+
+# Ask for each footage directory individually
+echo "Do you need specific footage directories?"
+read -p "Include Footage from A7III? (y/n): " include_a7iii
+read -p "Include Screen Footage? (y/n): " include_screen
+read -p "Include iPad Footage? (y/n): " include_ipad
+read -p "Include iPhone Footage? (y/n): " include_iphone
+read -p "Include GoPro Footage? (y/n): " include_gopro
+
+# Conditional removal of unwanted directories
+[[ "$include_a7iii" != "y" ]] && rm -r "${new_project_dir}/03 Footage_A7III"
+[[ "$include_screen" != "y" ]] && rm -r "${new_project_dir}/04 Footage_Screen"
+[[ "$include_ipad" != "y" ]] && rm -r "${new_project_dir}/05 Footage_iPad"
+[[ "$include_iphone" != "y" ]] && rm -r "${new_project_dir}/07 Footage_iPhone"
+[[ "$include_gopro" != "y" ]] && rm -r "${new_project_dir}/08 Footage_GPro"
+
+echo "Project directory created successfully."


### PR DESCRIPTION
- Introduce `create_project.sh` for setting up new Premiere Pro projects using a template directory and allowing selective footage inclusion.
- Add `backup_project.sh` to automate backing up existing Premiere Pro projects by locating and moving project folders, and handling file organization.
- Create README.md files for both scripts providing detailed usage instructions, features, and system requirements.
- Enhance script functionality to prompt for user input and handle dynamic directory paths.